### PR TITLE
Add error handling to Lever post_resource

### DIFF
--- a/lib/lever/client.rb
+++ b/lib/lever/client.rb
@@ -118,14 +118,16 @@ module Lever
       get_resource('/archive_reasons', Lever::ArchiveReason, nil, { on_error: on_error, query: { type: 'hired' } })
     end
 
-    def add_note(opportunity_id, body)
-      post_resource("/opportunities/#{opportunity_id}/notes", { value: body })
+    def add_note(opportunity_id, body, raise_http_errors: false)
+      post_resource("/opportunities/#{opportunity_id}/notes", { value: body }, raise_http_errors: raise_http_errors)
     end
 
-    def post_resource(path, body)
+    def post_resource(path, body, raise_http_errors: false)
       response = self.class.post("#{base_uri}#{path}", @options.merge({ body: body }))
 
-      if response.success?
+      # to preserve backward compatibilty, raising errors is disabled by default
+      # omit the optional raise_http_errors flag to retain the legacy behavior
+      if response.success? || !raise_http_errors
         response.parsed_response
       else
         error = case response.code


### PR DESCRIPTION
## Description of the change

Currently the `post_resource` method returns the HTTP response body without checking for error codes, making it impossible to determine whether a request succeeded or failed when using the client.

This PR adds the same logic used in `get_resource` to raise the appropriate `Lever::Error` when a `POST` request fails.

Currently this method is only being used by the `add_note` method.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] Schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] All UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [x] The code changed/added does not introduce security vulnerabilities

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] At least one other engineer confirms that schema changes (if applicable) will play nicely with "rolling" deploy mechanism
- [ ] At least one other engineer confirms that all UX vectors have been considered (desktop app, Chrome extension, responsive view)
- [ ] At least one other engineer has confirmed that the code changed/added will not introduce security vulnerabilities
- [ ] Issue from task tracker has a link to this pull request
