### PR TITLE
dehydrate resources by default

### DIFF
--- a/lib/lever/resource_collection.rb
+++ b/lib/lever/resource_collection.rb
@@ -17,13 +17,14 @@ module Lever
   class ResourceCollection
     include Enumerable
 
-    attr_accessor :client, :query_params, :resource_class
+    attr_accessor :client, :query_params, :resource_class, :dehydrate_after_iteration
 
-    def initialize(client:, query_params: {}, resource_class:)
+    def initialize(client:, query_params: {}, resource_class:, dehydrate_after_iteration: true)
       self.client             = client
       self.query_params       = query_params
       self.resource_class     = resource_class # e.g. Lever::Opportunity
       self.hydrated_resources = []
+      self.dehydrate_after_iteration = dehydrate_after_iteration
     end
 
     def each
@@ -37,6 +38,7 @@ module Lever
         end
 
         yield hydrated_resources[i]
+        hydrated_resources[i] = :dehydrated if dehydrate_after_iteration
         i += 1
       end
 

--- a/lib/lever/version.rb
+++ b/lib/lever/version.rb
@@ -1,3 +1,3 @@
 module Lever
-  VERSION = '0.1.7'
+  VERSION = '0.2.7'
 end

--- a/spec/lever/opportunity_collection_spec.rb
+++ b/spec/lever/opportunity_collection_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Lever::OpportunityCollection do
+  context 'with fake/ugly page of fake results' do
+    let(:collection) do
+      described_class.new(client: OpenStruct.new).tap do |instance|
+        instance.instance_variable_set('@all_pages_requested', true)
+        instance.instance_variable_set('@hydrated_resources', [1, 2, 3, 4, 5])
+      end
+    end
+
+    it 'dehydrates on iteration by default' do
+      collection.each do |val|
+        expect(val).to be_a Numeric
+      end
+
+      collection.each do |val|
+        expect(val).to eq :dehydrated
+      end
+    end
+  end
+end


### PR DESCRIPTION
- porting over https://github.com/Grayscale-Labs/greenhouse_io/pull/28
- https://app.shortcut.com/grayscale/story/9364/port-memory-savings-to-lever-gem

We've been noticing some memory usage spikes when Lever-related jobs are running in sidekiq, and @ledbettj dug deep enough to show this gem trying to build a huge list of API results. Then I remembered some memory savings hacks I did to this caching-enumerator in other spots, so maybe this is helpful here too.

This is breaking down the benefits of caching, since the cache is ruined after using it once (maybe saying "who needs this cache anyways"). `.count` (with no block) is the only thing that this keeps functional. The array will still be unwieldy and large, and certain operations/mutations on it will be slow when there are thousands of symbol entries in there.